### PR TITLE
Make useTheme utility more flexible in order to handle components migration

### DIFF
--- a/react-examples/themed-button/Button.js
+++ b/react-examples/themed-button/Button.js
@@ -1,10 +1,18 @@
+/**
+ * This is demonstrating a plain React button using standard coding practises, which:
+ *   1. Accept standard classes for styling (also consider usage of popular libraries like https://github.com/JedWatson/classnames)
+ *   2. Or accept arbitrary props for styling or non styling reasons. eg. icon='star'
+ * Forcing anything like props.theme would hinder migration of existing components
+ */
+
 import React from 'react'
 
 export default function Button(props) {
-  const {classes} = props.theme
+  const {classes} = props.classes  // eg. { button: 'class-to-use-on-button', icon: 'class-to-use-on-icon' }
+
   return (
     <button className={classes.button}>
-      <span className={classes.icon}></span>
+      <span className={classes.icon} icon={props.icon}></span>
     </button>
   )
 }

--- a/react-examples/themed-button/app.js
+++ b/react-examples/themed-button/app.js
@@ -12,12 +12,18 @@ const theme = {
 
 // ThemedButton component has now Theme built in, we don't need to pass it over
 // every time we use it.
-const ThemedButton = useTheme(Button, theme)
+const ThemedButton = useTheme(Button, { classes: theme.classes })
 
 export default function App() {
   return (
     <div>
-      <ThemedButton />
+      <ThemedButton icon="star" />
     </div>
   )
+  // compared with using plain components where styling props have to be manually passed in
+  // (
+  //   <div>
+  //     <Button classes={{ button: theme.classes.button, icon: theme.classes.icon }} icon="star" />
+  //   </div>
+  // )
 }

--- a/react-examples/themed-button/useTheme.js
+++ b/react-examples/themed-button/useTheme.js
@@ -3,10 +3,23 @@ import React, {PropTypes} from 'react'
 /**
  * Wrapps the passed component with a Theme component, which will always pass
  * the theme as a prop.
+ * NOTE: useTheme has challenge predicting what the original component expects
+ * @param {Object} Component - React component being wrapped
+ * @param {Object} themeMapping - mapping of theme to components props
  */
-export default function useTheme(Component, theme) {
+export default function useTheme(Component, themeMapping) {
   function Theme(props) {
-    return <Component {...props} theme={theme} />
+    let theme, rest;
+    // take theme related props out and map, then pass rest of them down
+    Object.keys(props).forEach((key, value) => {
+      if(themeMapping.hasOwnProperty(key)) {
+        theme.key = themMapping[key]
+      } else {
+        rest.key = value
+      }
+    })
+    // TODO: test this utility function and also add test/UI for all react-examples
+    return <Component {...theme} {...rest} />
   }
 
   Theme.propTypes = {


### PR DESCRIPTION
This is probably also related with how each of us perceives theme.

I feel if we define theme as nonintrusive styling guidelines, we can allow more flexible interpretation of how to use themes. To me the most challenge and compelling issue is the lack of industrial standard definition of theme, like wether to define font as a single choice or offer primary-font and secondary-font (which could eventually translate to \<h1\> \<h2\> or even \<button\>)

In this case I want to focus our effort on creating a standard theme definition, so that service companies can integrate each of their clients' theme easily into their customized product. Imagine I'm an marketing company offering customized mini-websites for my clients, my clients would want to apply their company color/font to the website with minimum effort, without I push them to provide list of color/font preference and company logo/banner, or they go back-and-forth review/comment on my design.

Focusing on just the standard and maximizing implementation flexibility will attract more people to evaluate and eventually use this spec.